### PR TITLE
The easiest fix of my life

### DIFF
--- a/TownSquareAPI/Services/ProfilePictureService.cs
+++ b/TownSquareAPI/Services/ProfilePictureService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,6 +32,17 @@ public class ProfilePictureService
     // Create a new ProfilePicture
     public async Task<ProfilePicture> CreateOrReplaceAsync(ProfilePicture profilePicture, CancellationToken cancellationToken)
     {
+        var existing = await _profilePictures.Find(p => p.UserId == profilePicture.UserId).FirstOrDefaultAsync(cancellationToken);
+
+        if (existing != null)
+        {
+            profilePicture.Id = existing.Id;
+        }
+        else
+        {
+            profilePicture.Id = ObjectId.GenerateNewId(); // or leave it if already generated
+        }
+
         var filter = Builders<ProfilePicture>.Filter.Eq(p => p.UserId, profilePicture.UserId);
         var options = new ReplaceOptions { IsUpsert = true };
 


### PR DESCRIPTION
Fix: Checks if the Id exists, if it does then it doesnt try and change it for _id is immuteable. If there is no _id it creates an ObjectId whereas before always set it to 00000... This solution is a little ugly in my opinion but it works and if I only need to work for 5 minutes then I only need to work for 5 minutes

